### PR TITLE
test draft release

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -16,4 +16,4 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-inference-proxy:0.0.13"
+    image: "ghcr.io/tinfoilsh/confidential-inference-proxy:0.0.18"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the proxy container image in tinfoil-config.yml to use version 0.0.18 instead of 0.0.13.

<!-- End of auto-generated description by cubic. -->

