### PR TITLE
fix: Strip Content-Length header for SSE streams

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -125,6 +125,10 @@ func newProxy(host, publicKeyFP, modelName string, billingCollector *billing.Col
 		// Replace the response body with our new reader
 		resp.Body = newBody
 
+		if streaming {
+			resp.Header.Del("Content-Length")
+		}
+
 		return nil
 	}
 

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -16,4 +16,4 @@ shim:
 
 containers:
   - name: "proxy"
-    image: "ghcr.io/tinfoilsh/confidential-inference-proxy:0.0.21"
+    image: "ghcr.io/tinfoilsh/confidential-inference-proxy:0.0.22"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the Content-Length header from server-sent event (SSE) streaming responses to prevent client-side issues with incomplete or hanging streams.

<!-- End of auto-generated description by cubic. -->

